### PR TITLE
chore(README): Fix Broken/Outdated Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ This package requires `@hyperlane-xyz/sdk`, `react`, and `react-dom`.
 
 ## Learn more
 
-For more information, see the [Hyperlane documentation](https://docs.hyperlane.xyz/hyperlane-docs/developers/getting-started).
+For more information, see the [Hyperlane documentation](https://docs.hyperlane.xyz/docs/intro).


### PR DESCRIPTION
The link to the documentation in the README was broken. This PR updates it to point to the correct documentation URL (https://docs.hyperlane.xyz/docs/intro). This ensures users have access to the relevant information.